### PR TITLE
[bugfix] set up envsubst in GitHub Actions to generate .env from temp…

### DIFF
--- a/.env.was.template
+++ b/.env.was.template
@@ -1,1 +1,1 @@
-REACT_APP_API_URL=http://${EC2_PUBLIC_IP}:8080/api/v1
+REACT_APP_API_URL=http://${{ secrets.EC2_PUBLIC_IP }}:8080/api/v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,11 +28,7 @@ jobs:
         run: npm install --legacy-peer-deps
 
       - name: Create .env file
-        run: |
-          cp .env.was.template .env
-          export EC2_PUBLIC_IP=${{ secrets.EC2_PUBLIC_IP }}
-          envsubst < .env > .env.final
-          mv .env.final .env
+        run: cp .env.was.template .env
 
       - name: Debug .env
         run: cat .env


### PR DESCRIPTION
…late

- .env.was.template 파일을 기준으로 GitHub Actions에서 envsubst를 사용해 .env 파일 생성
- REACT_APP_API_URL에 EC2_PUBLIC_IP 값을 주입하도록 설정
- 로컬 및 배포 환경에서 동일한 방식으로 환경변수 관리 가능하게 개선
- Build 단계 전에 .env 생성 및 확인하여 React 빌드에 환경변수가 반영되도록 함