### PR TITLE
[bugfix] correct envsubst usage to properly generate .env from template

### DIFF
--- a/.env.was.template
+++ b/.env.was.template
@@ -1,1 +1,1 @@
-REACT_APP_API_URL=http://${{ secrets.EC2_PUBLIC_IP }}:8080/api/v1
+REACT_APP_API_URL=http://${EC2_PUBLIC_IP}:8080/api/v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,9 @@ jobs:
         run: npm install --legacy-peer-deps
 
       - name: Create .env file
-        run: cp .env.was.template .env
+        run: |
+          export EC2_PUBLIC_IP=${{ secrets.EC2_PUBLIC_IP }}
+          envsubst '${EC2_PUBLIC_IP}' < .env.was.template > .env
 
       - name: Debug .env
         run: cat .env


### PR DESCRIPTION
- GitHub Actions deploy.yml 수정
- envsubst 명령어를 '${EC2_PUBLIC_IP}' 대상으로 명시적으로 지정
- .env.was.template 내부는 ${EC2_PUBLIC_IP} 형태로만 작성되도록 수정
- 빌드 전에 올바른 REACT_APP_API_URL 환경변수가 반영되도록 개선