### PR TITLE
[feat] 회원 관련 페이지 로직 개선 및 사용자 경험 향상

### DIFF
--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import "./SignupPage.css";
+import "./SignupPage.css"; // 로그인도 동일 스타일 사용
 import AxiosInstance from "../common/AxiosInstance";
 
 const LoginPage = () => {
@@ -11,6 +11,7 @@ const LoginPage = () => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    setError(""); // 이전 에러 초기화
 
     try {
       const { data } = await AxiosInstance.post("/members/login", {
@@ -19,20 +20,21 @@ const LoginPage = () => {
       });
 
       if (data.success) {
-        const memberInfo = data.data; // 서버 응답 MemberResponseDto
+        const memberInfo = data.data;
         localStorage.setItem("loginId", loginId);
         localStorage.setItem("memberId", memberInfo.memberId);
         localStorage.setItem("nickname", memberInfo.nickname);
-        localStorage.setItem("profileImageUrl", memberInfo.profileImageUrl || ""); // 추가 저장
+        localStorage.setItem("profileImageUrl", memberInfo.profileImageUrl || "");
+        localStorage.setItem("statusMessage", memberInfo.statusMessage || "");
 
         alert("로그인 성공!");
         navigate("/");
       } else {
-        setError(data.message || "로그인 실패");
+        setError(data.message || "아이디 또는 비밀번호가 올바르지 않습니다.");
       }
     } catch (err) {
       console.error(err);
-      setError("로그인 실패했습니다.");
+      setError("서버 오류로 로그인에 실패했습니다.");
     }
   };
 

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -16,6 +16,8 @@ const MainPage = () => {
     const statusMessage = localStorage.getItem("statusMessage");
 
     if (loginId) {
+      console.log("profileImageUrl = ", profileImageUrl);
+
       setIsLoggedIn(true);
       setNickname(nickname || "");
       setProfileImageUrl(profileImageUrl || "");

--- a/src/pages/SignupPage.jsx
+++ b/src/pages/SignupPage.jsx
@@ -15,9 +15,9 @@ const SignupPage = () => {
 
   const [errors, setErrors] = useState({});
   const [isUnique, setIsUnique] = useState({
-    loginId: false,
-    email: false,
-    nickname: false
+    loginId: true,
+    email: true,
+    nickname: true
   });
 
   const LOGIN_ID_POLICY = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{6,20}$/;
@@ -62,6 +62,7 @@ const SignupPage = () => {
       setIsUnique((prev) => ({ ...prev, loginId: data.data }));
     } catch (error) {
       console.error(error);
+      setIsUnique((prev) => ({ ...prev, loginId: true })); // 실패 시 "중복 아님" 처리
     }
   };
 
@@ -71,6 +72,7 @@ const SignupPage = () => {
       setIsUnique((prev) => ({ ...prev, email: data.data }));
     } catch (error) {
       console.error(error);
+      setIsUnique((prev) => ({ ...prev, email: true }));
     }
   };
 
@@ -82,12 +84,14 @@ const SignupPage = () => {
       setIsUnique((prev) => ({ ...prev, nickname: data.data }));
     } catch (error) {
       console.error(error);
+      setIsUnique((prev) => ({ ...prev, nickname: true }));
     }
   };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     if (!validatePolicy()) return;
+
     if (!isUnique.loginId || !isUnique.email || !isUnique.nickname) {
       alert("중복된 정보가 있습니다.");
       return;
@@ -118,7 +122,6 @@ const SignupPage = () => {
         headers: { "Content-Type": "multipart/form-data" }
       });
 
-      // 회원가입 성공 후 자동 로그인
       const { data } = await AxiosInstance.post("/members/login", {
         loginId: form.loginId,
         password: form.password
@@ -126,10 +129,12 @@ const SignupPage = () => {
 
       if (data.success) {
         localStorage.setItem("loginId", form.loginId);
-        localStorage.setItem("memberId", data.data.memberId); // ✅ 추가
+        localStorage.setItem("memberId", data.data.memberId);
         localStorage.setItem("nickname", data.data.nickname);
         localStorage.setItem("profileImageUrl", data.data.profileImageUrl || "");
         localStorage.setItem("statusMessage", data.data.statusMessage || "");
+        // console.log("profileImageUrl = ", profileImageUrl);
+
         alert("회원가입 및 로그인 성공!");
         navigate("/");
       }
@@ -148,7 +153,7 @@ const SignupPage = () => {
           <label>로그인 아이디</label>
           <input type="text" name="loginId" value={form.loginId} onChange={handleChange} />
           {errors.loginId && <p className="error-text">{errors.loginId}</p>}
-          {!isUnique.loginId && <p className="error-text">중복된 아이디입니다.</p>}
+          {form.loginId && !isUnique.loginId && <p className="error-text">중복된 아이디입니다.</p>}
         </div>
 
         {/* 비밀번호 */}
@@ -162,7 +167,7 @@ const SignupPage = () => {
         <div className="form-group">
           <label>이메일</label>
           <input type="email" name="email" value={form.email} onChange={handleChange} />
-          {!isUnique.email && <p className="error-text">중복된 이메일입니다.</p>}
+          {form.email && !isUnique.email && <p className="error-text">중복된 이메일입니다.</p>}
         </div>
 
         {/* 닉네임 */}
@@ -170,7 +175,9 @@ const SignupPage = () => {
           <label>닉네임</label>
           <input type="text" name="nickname" value={form.nickname} onChange={handleChange} />
           {errors.nickname && <p className="error-text">{errors.nickname}</p>}
-          {!isUnique.nickname && <p className="error-text">중복된 닉네임입니다.</p>}
+          {form.nickname && !isUnique.nickname && (
+            <p className="error-text">중복된 닉네임입니다.</p>
+          )}
         </div>
 
         {/* 상태 메시지 */}

--- a/src/pages/UpdateProfilePage.jsx
+++ b/src/pages/UpdateProfilePage.jsx
@@ -22,7 +22,6 @@ const UpdateProfilePage = () => {
         }
 
         const { data } = await AxiosInstance.get(`/members/id/${memberId}`);
-
         if (data.success && data.data) {
           const member = data.data;
           setForm({
@@ -33,7 +32,7 @@ const UpdateProfilePage = () => {
             statusMessage: member.statusMessage || "",
             password: "",
             profileImage: null,
-            profileImageUrl: member.profileImageUrl || "" // ✅ 기존 프로필 이미지 경로 저장
+            profileImageUrl: member.profileImageUrl || ""
           });
         } else {
           alert("회원 정보를 불러올 수 없습니다.");
@@ -75,18 +74,11 @@ const UpdateProfilePage = () => {
     try {
       const formData = new FormData();
       const memberDataBlob = new Blob(
-        [
-          JSON.stringify({
-            password: form.password,
-            statusMessage: form.statusMessage
-          })
-        ],
+        [JSON.stringify({ password: form.password, statusMessage: form.statusMessage })],
         { type: "application/json" }
       );
 
       formData.append("memberUpdateRequestDto", memberDataBlob);
-
-      // 파일을 새로 선택한 경우만 파일 추가
       if (form.profileImage) {
         formData.append("file", form.profileImage);
       }
@@ -96,7 +88,6 @@ const UpdateProfilePage = () => {
       });
 
       if (data.success) {
-        // localStorage 업데이트
         localStorage.setItem("nickname", data.data.nickname);
         localStorage.setItem(
           "profileImageUrl",
@@ -106,7 +97,7 @@ const UpdateProfilePage = () => {
 
         alert("프로필 업데이트가 완료되었습니다!");
         navigate("/");
-        window.location.reload(); // 메인페이지 새로고침해서 최신 데이터 반영
+        window.location.reload();
       } else {
         alert("업데이트에 실패했습니다.");
       }
@@ -126,25 +117,21 @@ const UpdateProfilePage = () => {
       <form className="signup-form" onSubmit={handleSubmit}>
         <div className="form-group">
           <label>로그인 아이디</label>
-          <input type="text" name="loginId" value={form.loginId} disabled />
+          <input type="text" value={form.loginId} disabled />
         </div>
-
         <div className="form-group">
           <label>이메일</label>
-          <input type="email" name="email" value={form.email} disabled />
+          <input type="email" value={form.email} disabled />
         </div>
-
         <div className="form-group">
           <label>닉네임</label>
-          <input type="text" name="nickname" value={form.nickname} disabled />
+          <input type="text" value={form.nickname} disabled />
         </div>
-
         <div className="form-group">
           <label>비밀번호</label>
           <input type="password" name="password" value={form.password} onChange={handleChange} />
           {errors.password && <p className="error-text">{errors.password}</p>}
         </div>
-
         <div className="form-group">
           <label>상태 메시지</label>
           <input
@@ -154,12 +141,10 @@ const UpdateProfilePage = () => {
             onChange={handleChange}
           />
         </div>
-
         <div className="form-group">
           <label>프로필 이미지</label>
           <input type="file" accept="image/*" onChange={handleFileChange} />
         </div>
-
         <button type="submit" className="submit-button">
           프로필 업데이트
         </button>


### PR DESCRIPTION
- MainPage: 로그인 시 프로필 이미지가 없을 경우 대체 이미지 미출력 버그 수정
- SignupPage: 중복 검사 로직 개선 및 유효성 검사 메시지 명확화
- UpdateProfilePage: 상태 메시지 및 프로필 이미지 변경 시 localStorage 반영 로직 보완
- LoginPage: 로그인 실패 시 에러 메시지 사용자에게 명확히 표시