### PR TITLE
[feat] 채점 현황 페이지 구현 및 제출 목록 조회 기능 연동

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import ProblemListPage from "./pages/ProblemListPage";
 import ProblemSolvePage from "./pages/ProblemSolvePage";
 import RankingPage from "./pages/RankingPage";
 import MemberDetailPage from "./pages/MemberDetailPage";
+import SubmissionListPage from "./pages/SubmissionListPage";
 
 function App() {
   return (
@@ -22,6 +23,7 @@ function App() {
         <Route path="/problems/:problemId" element={<ProblemSolvePage />} />
         <Route path="/ranking" element={<RankingPage />} />
         <Route path="/members/:memberId" element={<MemberDetailPage />} />
+        <Route path="/submissions" element={<SubmissionListPage />} />
       </Routes>
     </Router>
   );

--- a/src/components/submission/SubmissionPagination.jsx
+++ b/src/components/submission/SubmissionPagination.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+const SubmissionPagination = ({ hasNext, hasPrev, onNext, onPrev }) => {
+  return (
+    <div className="flex justify-between mt-4">
+      <button
+        onClick={onPrev}
+        disabled={!hasPrev}
+        className="px-4 py-2 bg-gray-300 rounded disabled:opacity-50"
+      >
+        이전
+      </button>
+      <button
+        onClick={onNext}
+        disabled={!hasNext}
+        className="px-4 py-2 bg-blue-500 text-white rounded disabled:opacity-50"
+      >
+        다음
+      </button>
+    </div>
+  );
+};
+
+export default SubmissionPagination;

--- a/src/components/submission/SubmissionRow.jsx
+++ b/src/components/submission/SubmissionRow.jsx
@@ -1,0 +1,40 @@
+import React from "react";
+
+const SubmissionRow = ({ submission }) => {
+  const {
+    submissionId,
+    nickname,
+    problemId,
+    problemTitle,
+    status,
+    message,
+    executionTime,
+    memoryUsage,
+    codeName
+  } = submission;
+
+  const statusColor =
+    status === "AC"
+      ? "text-green-600"
+      : status === "WA"
+        ? "text-red-600"
+        : status === "CE"
+          ? "text-purple-600"
+          : "text-blue-600";
+
+  return (
+    <tr>
+      <td className="p-2 border">{submissionId}</td>
+      <td className="p-2 border">{nickname}</td>
+      <td className="p-2 border">
+        {problemId} {problemTitle}
+      </td>
+      <td className={`p-2 border font-semibold ${statusColor}`}>{message}</td>
+      <td className="p-2 border">{executionTime ?? "-"} ms</td>
+      <td className="p-2 border">{memoryUsage ?? "-"} KB</td>
+      <td className="p-2 border">{codeName}</td>
+    </tr>
+  );
+};
+
+export default SubmissionRow;

--- a/src/components/submission/SubmissionTable.jsx
+++ b/src/components/submission/SubmissionTable.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+import SubmissionRow from "./SubmissionRow";
+
+const SubmissionTable = ({ submissions }) => {
+  return (
+    <table className="w-full border text-sm text-left">
+      <thead className="bg-gray-100">
+        <tr>
+          <th className="p-2 border">제출 번호</th>
+          <th className="p-2 border">아이디</th>
+          <th className="p-2 border">문제</th>
+          <th className="p-2 border">결과</th>
+          <th className="p-2 border">시간</th>
+          <th className="p-2 border">메모리</th>
+          <th className="p-2 border">언어</th>
+        </tr>
+      </thead>
+      <tbody>
+        {submissions.map((s) => (
+          <SubmissionRow key={s.submissionId} submission={s} />
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+export default SubmissionTable;

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -86,6 +86,10 @@ const MainPage = () => {
         <Link to="/problems">
           <button style={{ margin: "10px", padding: "10px 20px", fontSize: "16px" }}>문제</button>
         </Link>
+
+        <Link to="/submissions">
+          <button style={{ padding: "10px 20px", fontSize: "16px" }}>채점 현황</button>
+        </Link>
       </div>
     </div>
   );

--- a/src/pages/SubmissionListPage.jsx
+++ b/src/pages/SubmissionListPage.jsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from "react";
+import AxiosInstance from "../common/AxiosInstance";
+import SubmissionTable from "../components/submission/SubmissionTable";
+import SubmissionPagination from "../components/submission/SubmissionPagination";
+
+const SubmissionListPage = () => {
+  const [submissions, setSubmissions] = useState([]);
+  const [hasNext, setHasNext] = useState(false);
+  const [hasPrev, setHasPrev] = useState(false);
+  const [firstSeenId, setFirstSeenId] = useState(null);
+  const [lastSeenId, setLastSeenId] = useState(null);
+  const size = 20;
+
+  const fetchSubmissions = async (params = {}) => {
+    try {
+      const response = await AxiosInstance.get("/submissions/page", { params });
+      const { content, hasNext, hasPrev } = response.data.data;
+
+      console.log(content);
+
+      setSubmissions(content);
+      setHasNext(hasNext);
+      setHasPrev(hasPrev);
+
+      if (content.length > 0) {
+        setFirstSeenId(content[0].submissionId);
+        setLastSeenId(content[content.length - 1].submissionId);
+      }
+    } catch (error) {
+      console.error("Failed to fetch submissions:", error);
+    }
+  };
+
+  useEffect(() => {
+    fetchSubmissions();
+  }, []);
+
+  return (
+    <div className="p-6">
+      <h2 className="text-xl font-bold mb-4">채점 현황</h2>
+      <SubmissionTable submissions={submissions} />
+      <SubmissionPagination
+        hasNext={hasNext}
+        hasPrev={hasPrev}
+        onNext={() => fetchSubmissions({ lastSeenId, size })}
+        onPrev={() => fetchSubmissions({ firstSeenId, size })}
+      />
+    </div>
+  );
+};
+
+export default SubmissionListPage;


### PR DESCRIPTION
- /submissions 라우트에 SubmissionListPage 연결
- 제출 목록 조회를 위한 Axios GET 요청 구현
- 최초 조회, 이전/다음 페이지네이션 로직 구현
- SubmissionTable, SubmissionRow, SubmissionPagination 컴포넌트 분리 및 재사용성 고려한 설계
- MainPage에 '채점 현황' 버튼 추가 및 버튼 레이아웃 정렬 (flex 적용)
- React 상태 기반으로 제출 목록을 페이징 처리하고 화면에 출력되도록 처리