### PR TITLE
[feat] max-len 초과 라인 줄바꿈 및 템플릿 리터럴 분할 적용

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,8 @@
     "source.fixAll.eslint": "explicit"
   },
   "editor.formatOnSave": true,
+  "prettier.printWidth": 100,
+  "prettier.jsxSingleQuote": false,
   "eslint.validate": ["javascript", "javascriptreact"],
   "eslint.alwaysShowStatus": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode", // ✅ Prettier 확장 설치 필요

--- a/src/components/AuthButtonGroup.jsx
+++ b/src/components/AuthButtonGroup.jsx
@@ -6,7 +6,7 @@ const baseButtonClass =
 
 const AuthButtonGroup = ({ isLoggedIn, onLogout, onUpdate }) => {
   return (
-    <div className="mt-6 flex flex-wrap justify-center">
+    <div className="flex flex-wrap justify-center mt-6">
       {isLoggedIn ? (
         <>
           <button onClick={onLogout} className={baseButtonClass}>

--- a/src/components/ProblemDetail.jsx
+++ b/src/components/ProblemDetail.jsx
@@ -2,17 +2,17 @@ import React from "react";
 
 const ProblemDetail = ({ problem }) => {
   return (
-    <div className="flex-1 p-8 bg-gray-50 border-2 border-gray-100 rounded-2xl">
-      <h3 className="text-lg font-semibold mb-2">문제 설명</h3>
-      <p className="whitespace-pre-line leading-relaxed text-gray-800">{problem.description}</p>
+    <div className="flex-1 p-8 border-2 border-gray-100 bg-gray-50 rounded-2xl">
+      <h3 className="mb-2 text-lg font-semibold">문제 설명</h3>
+      <p className="leading-relaxed text-gray-800 whitespace-pre-line">{problem.description}</p>
 
-      <h3 className="text-lg font-semibold mt-8 mb-2">입력</h3>
-      <p className="whitespace-pre-line leading-relaxed text-gray-800">
+      <h3 className="mt-8 mb-2 text-lg font-semibold">입력</h3>
+      <p className="leading-relaxed text-gray-800 whitespace-pre-line">
         {problem.inputDescription}
       </p>
 
-      <h3 className="text-lg font-semibold mt-8 mb-2">출력</h3>
-      <p className="whitespace-pre-line leading-relaxed text-gray-800">
+      <h3 className="mt-8 mb-2 text-lg font-semibold">출력</h3>
+      <p className="leading-relaxed text-gray-800 whitespace-pre-line">
         {problem.outputDescription}
       </p>
     </div>


### PR DESCRIPTION
- ESLint max-len(120) 규칙 위반 항목을 줄바꿈 또는 템플릿 리터럴로 분리하여 해결
- SignupPage, UpdateProfilePage, ProblemDetail, SubmissionCard, ProfileImage 등 다수 컴포넌트 수정
- 코드 가독성 유지하면서 린트 경고 제거