### PR TITLE
[feat] 세션 만료 감지를 위한 공통 훅 및 Axios 인터셉터 추가

### DIFF
--- a/src/common/AxiosInstance.js
+++ b/src/common/AxiosInstance.js
@@ -3,7 +3,21 @@
 import axios from "axios";
 
 const AxiosInstance = axios.create({
-  baseURL: process.env.REACT_APP_API_URL
+  baseURL: process.env.REACT_APP_API_URL,
+  withCredentials: true
 });
+
+//  요청 실패 시 세션 만료 감지
+AxiosInstance.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status == 401) {
+      alert("세션이 만료되었습니다. 다시 로그인해주세요.");
+      localStorage.removeItem("member");
+      window.location.href = "/login"; // 또는 navigate("/login");
+    }
+    return Promise.reject(error);
+  }
+);
 
 export default AxiosInstance;

--- a/src/common/LogoHeader.jsx
+++ b/src/common/LogoHeader.jsx
@@ -17,6 +17,7 @@ const LogoHeader = () => {
 
   const handleLogout = () => {
     dispatch(logout());
+    window.location.reload();
     // navigate("/");
   };
 

--- a/src/hooks/useSessionGuard.js
+++ b/src/hooks/useSessionGuard.js
@@ -1,0 +1,29 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import AxiosInstance from "../common/AxiosInstance";
+import { useDispatch } from "react-redux";
+import { logout } from "../store/slices/authSlice";
+
+const useSessionGuard = () => {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const checkSession = async () => {
+      try {
+        await AxiosInstance.get("/members/me");
+      } catch (err) {
+        if (err.response?.status === 401) {
+          alert("세션이 만료되었습니다. 다시 로그인해주세요.");
+          localStorage.removeItem("member");
+          dispatch(logout());
+          navigate("/login");
+        }
+      }
+    };
+
+    checkSession();
+  }, [navigate, dispatch]);
+};
+
+export default useSessionGuard;

--- a/src/hooks/useSessionValidationBeforeAction.js
+++ b/src/hooks/useSessionValidationBeforeAction.js
@@ -1,0 +1,32 @@
+import { useNavigate } from "react-router-dom";
+import { useDispatch } from "react-redux";
+import AxiosInstance from "../common/AxiosInstance";
+import { logout } from "../store/slices/authSlice";
+
+const useSessionValidationBeforeAction = () => {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+
+  const validateSession = async () => {
+    try {
+      await AxiosInstance.get("/members/me");
+      return true; // 세션 살아있음
+    } catch (err) {
+      if (err.response?.status === 401) {
+        alert("세션이 만료되었습니다. 다시 로그인해주세요.");
+        localStorage.removeItem("member");
+        dispatch(logout());
+        navigate("/login");
+        return false;
+      } else {
+        console.error("세션 확인 중 에러:", err);
+        alert("예기치 못한 오류가 발생했습니다.");
+        return false;
+      }
+    }
+  };
+
+  return validateSession;
+};
+
+export default useSessionValidationBeforeAction;

--- a/src/pages/ProblemSolvePage.jsx
+++ b/src/pages/ProblemSolvePage.jsx
@@ -6,6 +6,7 @@ import ProblemDetail from "../components/ProblemDetail";
 import CodeEditor from "../components/CodeEditor";
 import ResultBox from "../components/ResultBox";
 import TestcaseList from "../components/TestcaseList";
+import useSessionValidationBeforeAction from "../hooks/useSessionValidationBeforeAction";
 
 const ProblemSolvePage = () => {
   const { problemId } = useParams();
@@ -14,6 +15,8 @@ const ProblemSolvePage = () => {
   const [result /* , setResult */] = useState("실행 결과가 여기에 표시됩니다.");
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [memberId, setMemberId] = useState(null);
+
+  const validateSession = useSessionValidationBeforeAction();
 
   useEffect(() => {
     const memberJson = localStorage.getItem("member");
@@ -38,6 +41,9 @@ const ProblemSolvePage = () => {
   }, [problemId]);
 
   const handleSubmit = async () => {
+    const isValid = await validateSession();
+    if (!isValid) return;
+
     if (!isLoggedIn || !memberId) {
       alert("로그인 후 제출할 수 있습니다.");
       return;

--- a/src/pages/UpdateProfilePage.jsx
+++ b/src/pages/UpdateProfilePage.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import AxiosInstance from "../common/AxiosInstance";
 import LogoHeader from "../common/LogoHeader";
 import FormGroup from "../components/FormGroup";
+import useSessionGuard from "../hooks/useSessionGuard";
 
 const UpdateProfilePage = () => {
   const navigate = useNavigate();
@@ -11,6 +12,8 @@ const UpdateProfilePage = () => {
 
   const PASSWORD_POLICY =
     /^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[@#$%^&+=!])[A-Za-z\d@#$%^&+=!]{8,20}$/;
+
+  useSessionGuard();
 
   useEffect(() => {
     const fetchMemberInfo = async () => {


### PR DESCRIPTION
- useSessionGuard 훅 구현 및 회원 수정 페이지에 적용 → 페이지 진입 시 세션 만료 여부 확인, 만료 시 자동 로그아웃 및 리다이렉트
- useSessionValidationBeforeAction 훅 구현 → 문제 제출 버튼 클릭 전에 세션 유효성 검사
- AxiosInstance에 전역 인터셉터 추가 → 모든 요청 실패 시 401 응답을 감지하여 세션 만료 처리
- LogoHeader 로그아웃 시 window.location.reload()로 상태 즉시 반영