### PR TITLE
[feat] 제출 코드 보기 기능 추가 및 프로필 이미지 용량 제한 설정

### DIFF
--- a/src/components/submission/CodeModal.jsx
+++ b/src/components/submission/CodeModal.jsx
@@ -1,0 +1,24 @@
+// src/components/submission/CodeModal.jsx
+import React from "react";
+
+const CodeModal = ({ isOpen, codeContent, onClose }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40">
+      <div className="w-full max-w-2xl p-4 bg-white rounded shadow-lg">
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-lg font-semibold">제출한 코드</h2>
+          <button onClick={onClose} className="text-gray-500 hover:text-black">
+            ✖
+          </button>
+        </div>
+        <pre className="p-2 overflow-auto text-sm bg-gray-100 rounded max-h-[70vh] whitespace-pre-wrap">
+          {codeContent}
+        </pre>
+      </div>
+    </div>
+  );
+};
+
+export default CodeModal;

--- a/src/components/submission/SubmissionCard.jsx
+++ b/src/components/submission/SubmissionCard.jsx
@@ -1,5 +1,7 @@
-import React from "react";
+import React, { useState } from "react";
 import { Link } from "react-router-dom";
+import AxiosInstance from "../../common/AxiosInstance";
+import CodeModal from "./CodeModal";
 
 const getStatusStyle = (status) => {
   switch (status) {
@@ -30,17 +32,32 @@ const SubmissionCard = ({ submission }) => {
     status
   } = submission;
 
-  console.log("submission = ", submission);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [codeContent, setCodeContent] = useState("");
+
+  const handleCodeClick = async () => {
+    try {
+      const { data } = await AxiosInstance.get(`/submissions/${submissionId}/code`);
+      setCodeContent(data.data);
+      setIsModalOpen(true);
+    } catch (error) {
+      alert("코드를 불러오는 데 실패했습니다.");
+      console.error(error);
+    }
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+    setCodeContent("");
+  };
 
   return (
-    <div className="px-6 py-4 transition bg-white border border-gray-200 rounded-lg shadow-sm hover:shadow-md">
-      {/* 상단: 제출번호 + 결과 메시지 */}
+    <div className="relative px-6 py-4 transition bg-white border border-gray-200 rounded-lg shadow-sm hover:shadow-md">
       <div className="flex items-center justify-between mb-2 text-sm text-gray-500">
         <span>제출 #{submissionId}</span>
         <span className={getStatusStyle(status)}>{message}</span>
       </div>
 
-      {/* 문제 번호와 제목 */}
       <Link
         to={`/problems/${problemId}`}
         className="block mb-1 text-lg font-bold text-gray-900 hover:underline"
@@ -48,17 +65,19 @@ const SubmissionCard = ({ submission }) => {
         {problemId}. {problemTitle}
       </Link>
 
-      {/* 제출자 */}
       <Link to={`/members/${memberId}`} className="mb-3 text-sm text-gray-500 hover:underline">
         제출자: {nickname}
       </Link>
 
-      {/* 시간, 메모리, 언어 */}
       <div className="flex flex-wrap gap-4 text-sm text-gray-500">
         <span>⏱ {executionTime ?? "-"} ms</span>
         <span>💾 {memoryUsage ?? "-"} KB</span>
-        <span>💻 {codeName}</span>
+        <button onClick={handleCodeClick} className="text-blue-600 hover:underline">
+          💻 {codeName}
+        </button>
       </div>
+
+      <CodeModal isOpen={isModalOpen} codeContent={codeContent} onClose={closeModal} />
     </div>
   );
 };

--- a/src/pages/SignupPage.jsx
+++ b/src/pages/SignupPage.jsx
@@ -43,6 +43,16 @@ const SignupPage = () => {
 
   const handleFileChange = (e) => {
     const file = e.target.files[0];
+
+    const maxSizeInMB = 1;
+    const maxSizeInBytes = maxSizeInMB * 1024 * 1024;
+
+    if (file.size > maxSizeInBytes) {
+      alert("파일 용량이 1MB를 초과합니다. 다른 이미지를 선택해주세요.");
+      e.target.value = null; // 선택된 파일 초기화
+      return;
+    }
+
     setForm((prev) => ({ ...prev, profileImage: file }));
   };
 


### PR DESCRIPTION
- CodeModal 컴포넌트를 분리하여 코드 보기 모달 UI 재사용 가능하도록 구성
- 제출 카드에서 💻 클릭 시 /submissions/{id}/code API 호출 후 코드 모달 표시
- SignupPage에서 프로필 이미지 파일 용량이 1MB 초과 시 업로드 제한