### PR TITLE
[feat] 회원 제출 수 표시 및 제출 내역 이동 기능 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -24,6 +24,7 @@ function App() {
         <Route path="/ranking" element={<RankingPage />} />
         <Route path="/members/:memberId" element={<MemberDetailPage />} />
         <Route path="/submissions" element={<SubmissionListPage />} />
+        <Route path="/submissions/member/:memberId" element={<SubmissionListPage />} />
       </Routes>
     </Router>
   );

--- a/src/pages/MemberDetailPage.jsx
+++ b/src/pages/MemberDetailPage.jsx
@@ -8,6 +8,7 @@ const MemberDetailPage = () => {
   const { memberId } = useParams();
   const navigate = useNavigate();
   const [member, setMember] = useState(null);
+  const [submissionCount, setSubmissionCount] = useState(null);
 
   useEffect(() => {
     const fetchMember = async () => {
@@ -24,31 +25,52 @@ const MemberDetailPage = () => {
       }
     };
 
+    const fetchSubmissionCount = async () => {
+      try {
+        const res = await AxiosInstance.get(`/submissions/page/member/${memberId}?size=1`);
+        setSubmissionCount(res.data.data.totalCount);
+      } catch (err) {
+        console.error(err);
+        setSubmissionCount(null);
+      }
+    };
+
     fetchMember();
+    fetchSubmissionCount();
   }, [memberId]);
+
+  const goToSubmissions = () => {
+    navigate(`/submissions/member/${memberId}`);
+  };
 
   if (!member) return null;
 
   return (
-    <div className="max-w-xl mx-auto px-4 py-10 text-center">
+    <div className="max-w-xl px-4 py-10 mx-auto text-center">
       <LogoHeader />
 
       <button
         onClick={() => navigate("/ranking")}
-        className="mt-6 mb-10 px-4 py-2 text-sm border border-gray-300 rounded bg-gray-100 hover:bg-gray-200 transition"
+        className="px-4 py-2 mt-6 mb-10 text-sm transition bg-gray-100 border border-gray-300 rounded hover:bg-gray-200"
       >
         ◀ 랭킹 페이지로
       </button>
 
-      <div className="bg-white border border-gray-200 rounded-md shadow p-6">
+      <div className="p-6 bg-white border border-gray-200 rounded-md shadow">
         <ProfileImage src={member.profileImageUrl} size={150} />
 
-        <h1 className="text-2xl font-bold mt-4 mb-2">{member.nickname}</h1>
+        <h1 className="mt-4 mb-2 text-2xl font-bold">{member.nickname}</h1>
 
-        <p className="text-gray-700 text-sm mb-1">아이디: {member.loginId}</p>
-        <p className="text-gray-700 text-sm mb-1">이메일: {member.email}</p>
-        <p className="text-gray-700 text-sm mb-1">푼 문제 수: {member.solved}</p>
-        <p className="text-gray-700 text-sm">상태 메시지: {member.statusMessage}</p>
+        <p className="mb-1 text-sm text-gray-700">아이디: {member.loginId}</p>
+        <p className="mb-1 text-sm text-gray-700">이메일: {member.email}</p>
+        <p className="mb-1 text-sm text-gray-700">푼 문제 수: {member.solved}</p>
+        <p className="mb-1 text-sm text-gray-700">
+          제출:{" "}
+          <span className="text-blue-500 cursor-pointer hover:underline" onClick={goToSubmissions}>
+            {submissionCount !== null ? `${submissionCount} 회` : "불러오는 중..."}
+          </span>
+        </p>
+        <p className="text-sm text-gray-700">상태 메시지: {member.statusMessage}</p>
       </div>
     </div>
   );

--- a/src/pages/ProblemSolvePage.jsx
+++ b/src/pages/ProblemSolvePage.jsx
@@ -67,7 +67,7 @@ const ProblemSolvePage = () => {
       const { data } = await AxiosInstance.post("/submissions", payload);
       if (data.success) {
         // alert("제출이 완료되었습니다!");
-        navigate("/submissions");
+        navigate(`/submissions/member/${memberId}`);
         console.log("제출 응답:", data.data);
       } else {
         alert("제출에 실패했습니다.");

--- a/src/pages/SubmissionListPage.jsx
+++ b/src/pages/SubmissionListPage.jsx
@@ -3,6 +3,7 @@ import AxiosInstance from "../common/AxiosInstance";
 import SubmissionCard from "../components/submission/SubmissionCard";
 import SubmissionPagination from "../components/submission/SubmissionPagination";
 import LogoHeader from "../common/LogoHeader";
+import { useParams } from "react-router-dom"; // 👈 memberId param 처리
 
 const SubmissionListPage = () => {
   const [submissions, setSubmissions] = useState([]);
@@ -10,18 +11,22 @@ const SubmissionListPage = () => {
   const [hasPrev, setHasPrev] = useState(false);
   const [firstSeenId, setFirstSeenId] = useState(null);
   const [lastSeenId, setLastSeenId] = useState(null);
+  const [totalCount, setTotalCount] = useState(null); // 👈 제출 수
   const size = 20;
+
+  const { memberId } = useParams(); // 👈 memberId가 있을 수도 있음
 
   const fetchSubmissions = async (params = {}) => {
     try {
-      const response = await AxiosInstance.get("/submissions/page", { params });
-      const { content, hasNext, hasPrev } = response.data.data;
+      const url = memberId ? `/submissions/page/member/${memberId}` : "/submissions/page";
 
-      console.log(content);
+      const response = await AxiosInstance.get(url, { params });
+      const { content, hasNext, hasPrev, totalCount } = response.data.data;
 
       setSubmissions(content);
       setHasNext(hasNext);
       setHasPrev(hasPrev);
+      setTotalCount(totalCount);
 
       if (content.length > 0) {
         setFirstSeenId(content[0].submissionId);
@@ -34,17 +39,25 @@ const SubmissionListPage = () => {
 
   useEffect(() => {
     fetchSubmissions();
-  }, []);
+  }, [memberId]);
 
   return (
     <div className="p-6">
       <LogoHeader />
       <h2 className="mb-4 text-xl font-bold">채점 현황</h2>
+
+      {memberId && totalCount !== null && (
+        <div className="mb-4 text-sm text-gray-600">
+          총 제출 수: <span className="font-semibold">{totalCount}</span> 회
+        </div>
+      )}
+
       <div className="grid gap-4">
         {submissions.map((s) => (
           <SubmissionCard key={s.submissionId} submission={s} />
         ))}
       </div>
+
       <SubmissionPagination
         hasNext={hasNext}
         hasPrev={hasPrev}


### PR DESCRIPTION
- MemberDetailPage에서 회원의 총 제출 수 표시 및 클릭 시 제출 내역 페이지로 이동하도록 기능 추가
- ProblemSolvePage 제출 후 해당 회원의 제출 내역 페이지로 이동하도록 라우팅 수정
- SubmissionListPage에서 memberId param을 받아 회원별 제출 목록 및 총 제출 수(totalCount) 표시
- App.js에 /submissions/member/:memberId 라우트 추가