### PR TITLE
[feat] 세션 만료 감지를 위한 useSessionGuard 전역 적용 및 조건 분기 개선

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,8 +10,11 @@ import ProblemSolvePage from "./pages/ProblemSolvePage";
 import RankingPage from "./pages/RankingPage";
 import MemberDetailPage from "./pages/MemberDetailPage";
 import SubmissionListPage from "./pages/SubmissionListPage";
+import useSessionGuard from "./hooks/useSessionGuard";
 
 function App() {
+  useSessionGuard(); //  5분마다 세션 체크
+
   return (
     <Router>
       <Routes>

--- a/src/hooks/useSessionGuard.js
+++ b/src/hooks/useSessionGuard.js
@@ -4,12 +4,15 @@ import AxiosInstance from "../common/AxiosInstance";
 import { useDispatch } from "react-redux";
 import { logout } from "../store/slices/authSlice";
 
-const useSessionGuard = () => {
+const useSessionGuard = (intervalMillis = 5 * 60 * 1000) => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
 
   useEffect(() => {
     const checkSession = async () => {
+      const memberJson = localStorage.getItem("member");
+      if (!memberJson) return; // 로그인 안 돼있으면 아무것도 하지 않음
+
       try {
         await AxiosInstance.get("/members/me");
       } catch (err) {
@@ -22,8 +25,10 @@ const useSessionGuard = () => {
       }
     };
 
-    checkSession();
-  }, [navigate, dispatch]);
+    checkSession(); //  첫 진입시 1회 검사
+    const interval = setInterval(checkSession, intervalMillis);
+    return () => clearInterval(interval);
+  }, [navigate, dispatch, intervalMillis]);
 };
 
 export default useSessionGuard;


### PR DESCRIPTION
- useSessionGuard 훅을 수정하여 로그인 상태일 때만 세션 유효성 검사 수행
- App.js에 useSessionGuard 전역 적용하여 모든 페이지에서 세션 만료 자동 감지
- 세션 만료 시 alert 표시 후 localStorage 초기화 및 Redux logout 처리