### PR TITLE
[feat] 회원 상세 페이지에서 푼 문제 수 클릭 시 푼 문제 목록 페이지로 이동 기능 추가

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,6 +21,7 @@ function App() {
         <Route path="/update-profile" element={<UpdateProfilePage />} />
         <Route path="/problems" element={<ProblemListPage />} />
         <Route path="/problems/:problemId" element={<ProblemSolvePage />} />
+        <Route path="/problems/solved/:memberId" element={<ProblemListPage />} />
         <Route path="/ranking" element={<RankingPage />} />
         <Route path="/members/:memberId" element={<MemberDetailPage />} />
         <Route path="/submissions" element={<SubmissionListPage />} />

--- a/src/pages/MemberDetailPage.jsx
+++ b/src/pages/MemberDetailPage.jsx
@@ -43,6 +43,10 @@ const MemberDetailPage = () => {
     navigate(`/submissions/member/${memberId}`);
   };
 
+  const goToSolvedProblems = () => {
+    navigate(`/problems/solved/${memberId}`);
+  };
+
   if (!member) return null;
 
   return (
@@ -63,7 +67,15 @@ const MemberDetailPage = () => {
 
         <p className="mb-1 text-sm text-gray-700">아이디: {member.loginId}</p>
         <p className="mb-1 text-sm text-gray-700">이메일: {member.email}</p>
-        <p className="mb-1 text-sm text-gray-700">푼 문제 수: {member.solved}</p>
+        <p className="mb-1 text-sm text-gray-700">
+          푼 문제 수:{" "}
+          <span
+            className="text-blue-500 cursor-pointer hover:underline"
+            onClick={goToSolvedProblems}
+          >
+            {member.solved}
+          </span>
+        </p>
         <p className="mb-1 text-sm text-gray-700">
           제출:{" "}
           <span className="text-blue-500 cursor-pointer hover:underline" onClick={goToSubmissions}>

--- a/src/pages/ProblemListPage.jsx
+++ b/src/pages/ProblemListPage.jsx
@@ -3,17 +3,21 @@ import LogoHeader from "../common/LogoHeader";
 import ProblemCard from "../components/ProblemCard";
 import Pagination from "../components/Pagination";
 import useFetchList from "../hooks/useFetchList";
+import { useParams } from "react-router-dom";
 
 const ProblemListPage = () => {
+  const { memberId } = useParams();
   const [pageNumber, setPageNumber] = useState(1);
   const pageSize = 100;
+
+  const url = memberId ? `/problems/solved/${memberId}` : "/problems";
 
   const {
     data: problems,
     totalCount,
     isLoading
   } = useFetchList(
-    "/problems",
+    url,
     {
       pageNumber,
       pageSize


### PR DESCRIPTION
- /problems/solved/:memberId 라우트 추가 및 ProblemListPage에서 URL 파라미터 기반 분기 처리
- MemberDetailPage에서 푼 문제 수 클릭 시 해당 회원의 풀이 문제 목록 페이지로 이동
- ProblemListPage에서 memberId 유무에 따라 전체 문제 vs 푼 문제 목록 조회하도록 로직 분기