### PR TITLE
[bugfix] 클라이언트 로그아웃 시 서버 세션도 함께 종료되도록 수정 및 중복 로직 통합

### DIFF
--- a/src/common/AxiosInstance.js
+++ b/src/common/AxiosInstance.js
@@ -13,8 +13,10 @@ AxiosInstance.interceptors.response.use(
   (error) => {
     const isLoginRequest = error.config?.url?.includes("/members/login");
 
+    console.log("url = ", error.config.url);
+
     if (error.response?.status == 401 && !isLoginRequest) {
-      alert("세션이 만료되었습니다. 다시 로그인해주세요.");
+      // alert("세션이 만료되었습니다. 다시 로그인해주세요.");
       localStorage.removeItem("member");
       window.location.href = "/login"; // 또는 navigate("/login");
     }

--- a/src/common/LogoHeader.jsx
+++ b/src/common/LogoHeader.jsx
@@ -1,16 +1,15 @@
 import React from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
-import { logout } from "../store/slices/authSlice";
+import { handleSessionLogout } from "../utils/session";
 
 const LogoHeader = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const { isLoggedIn } = useSelector((state) => state.auth);
 
-  const handleLogout = () => {
-    dispatch(logout());
-    window.location.reload();
+  const handleLogout = async () => {
+    await handleSessionLogout({ dispatch, navigate, silent: true });
   };
 
   const handleUpdate = () => {

--- a/src/hooks/useSessionGuard.js
+++ b/src/hooks/useSessionGuard.js
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import AxiosInstance from "../common/AxiosInstance";
 import { useDispatch } from "react-redux";
-import { logout } from "../store/slices/authSlice";
+import { handleSessionLogout } from "../utils/session";
 
 const useSessionGuard = () => {
   const navigate = useNavigate();
@@ -14,10 +14,7 @@ const useSessionGuard = () => {
         await AxiosInstance.get("/members/me");
       } catch (err) {
         if (err.response?.status === 401) {
-          alert("세션이 만료되었습니다. 다시 로그인해주세요.");
-          localStorage.removeItem("member");
-          dispatch(logout());
-          navigate("/login");
+          await handleSessionLogout({ dispatch, navigate, silent: false });
         }
       }
     };

--- a/src/hooks/useSessionValidationBeforeAction.js
+++ b/src/hooks/useSessionValidationBeforeAction.js
@@ -1,7 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import { useDispatch } from "react-redux";
 import AxiosInstance from "../common/AxiosInstance";
-import { logout } from "../store/slices/authSlice";
+import { handleSessionLogout } from "../utils/session";
 
 const useSessionValidationBeforeAction = () => {
   const navigate = useNavigate();
@@ -13,11 +13,7 @@ const useSessionValidationBeforeAction = () => {
       return true; // 세션 살아있음
     } catch (err) {
       if (err.response?.status === 401) {
-        alert("세션이 만료되었습니다. 다시 로그인해주세요.");
-        localStorage.removeItem("member");
-        dispatch(logout());
-        navigate("/login");
-        return false;
+        await handleSessionLogout({ dispatch, navigate, silent: false });
       } else {
         console.error("세션 확인 중 에러:", err);
         alert("예기치 못한 오류가 발생했습니다.");

--- a/src/utils/session.js
+++ b/src/utils/session.js
@@ -1,0 +1,17 @@
+import { logout } from "../store/slices/authSlice";
+import AxiosInstance from "../common/AxiosInstance";
+
+export const handleSessionLogout = async ({ dispatch, navigate, silent = false }) => {
+  try {
+    await AxiosInstance.post("/members/logout", null, { withCredentials: true });
+  } catch (e) {
+    console.warn("서버 로그아웃 실패", e);
+  } finally {
+    if (!silent) {
+      alert("세션이 만료되었습니다. 다시 로그인해주세요.");
+    }
+    localStorage.removeItem("member");
+    dispatch(logout());
+    navigate("/login");
+  }
+};


### PR DESCRIPTION
- 기존에는 logout 버튼 클릭 시 Redux 상태만 초기화하고 서버 로그아웃 API 호출이 누락되어 세션이 유지되는 문제가 있었음
- 이를 해결하기 위해 LogoHeader의 로그아웃 로직에 POST /members/logout 요청 추가
- useSessionGuard, useSessionValidationBeforeAction 등 세션 만료 시에도 같은 방식으로 서버 세션 종료되도록 통일
- handleSessionLogout 유틸 함수로 공통 로직을 통합해 코드 중복 제거
  - silent=true: 수동 로그아웃 시 알림창 생략
  - silent=false: 세션 만료 감지 시 경고창 표시
- AxiosInstance의 401 인터셉터에서는 alert만 제거하고 상태 초기화는 hook 내에서 담당하도록 유지