### PR TITLE
[feat] SubmissionSearchModal에 언어별 버전 매핑 기능 추가

### DIFF
--- a/src/components/search/SubmissionSearchModal.jsx
+++ b/src/components/search/SubmissionSearchModal.jsx
@@ -1,6 +1,10 @@
 import React, { useState } from "react";
 
 const SubmissionSearchModal = ({ isOpen, onClose, onSearch }) => {
+  const LANGUAGE_VERSION_MAP = {
+    Java: [1001, 1002, 1003, 1004]
+  };
+
   const [filters, setFilters] = useState({
     loginId: "",
     problemNumber: "",
@@ -22,8 +26,13 @@ const SubmissionSearchModal = ({ isOpen, onClose, onSearch }) => {
       Object.entries(filters).filter(([_, v]) => v && v.trim() !== "")
     );
 
-    // 아무것도 입력 안 했을 때
-    if (Object.keys(activeFilters).length === 0) return;
+    if (activeFilters.language) {
+      const versionIds = LANGUAGE_VERSION_MAP[activeFilters.language];
+      if (versionIds) {
+        activeFilters.languageVersionIds = versionIds.join(",");
+      }
+      delete activeFilters.language;
+    }
 
     onSearch(activeFilters);
   };


### PR DESCRIPTION
- LANGUAGE_VERSION_MAP 상수 추가 (Java → [1001, 1002, 1003, 1004])
- 검색 시 languageVersionIds 자동 생성 및 language 필드 제거
- onSearch 호출 시 매핑된 versionIds 포함하도록 로직 개선
- 빈 입력 필터 처리 및 유효성 로직 정리
- 언어 기준 검색 시 내부적으로 해당 언어 버전 ID 세트로 변환해 전달되도록 개선