### PR TITLE
[bugfix] SubmissionListPage 커서 기반 페이지네이션 시 검색 조건 초기화 문제 수정

### DIFF
--- a/src/pages/SubmissionListPage.jsx
+++ b/src/pages/SubmissionListPage.jsx
@@ -18,13 +18,20 @@ const SubmissionListPage = () => {
   const location = useLocation();
   const nickname = location.state?.nickname;
 
-  const fetchSubmissions = async (params = {}) => {
+  const fetchSubmissions = async (extraParams = {}) => {
     try {
       const url = memberId ? `/submissions/page/member/${memberId}` : "/submissions/search";
 
-      const response = await AxiosInstance.get(url, {
-        params: { size, ...params }
-      });
+      // 이전 검색조건 유지
+      const mergedParams = {
+        size,
+        ...searchParams,
+        ...extraParams
+      };
+
+      console.log("요청 파라미터:", mergedParams);
+
+      const response = await AxiosInstance.get(url, { params: mergedParams });
 
       const { content, hasNext, hasPrev, totalCount } = response.data.data;
 
@@ -47,11 +54,6 @@ const SubmissionListPage = () => {
     fetchSubmissions();
   }, [memberId]);
 
-  /** ✅ 검색 실행 */
-  /**
-   * 다중 조건 검색을 실행합니다.
-   * @param {Object} filters - { loginId, problemNumber, language, status, submissionId }
-   */
   const handleSearch = (filters) => {
     console.log("검색 조건:", filters);
 
@@ -123,10 +125,14 @@ const SubmissionListPage = () => {
         <CursorPagination
           hasNext={hasNext}
           hasPrev={hasPrev}
-          onNext={() => fetchSubmissions({ lastSeenId })}
-          onPrev={() => fetchSubmissions({ firstSeenId })}
+          onNext={() => {
+            if (lastSeenId) fetchSubmissions({ lastSeenId });
+          }}
+          onPrev={() => {
+            if (firstSeenId) fetchSubmissions({ firstSeenId });
+          }}
           onSearch={handleSearch}
-          searchTypes={memberId ? null : []} // 회원 모드에서는 검색 비활성화
+          searchTypes={memberId ? null : []}
         />
       </div>
     </div>


### PR DESCRIPTION
- fetchSubmissions
  - 기존 검색 상태(searchParams)를 유지하며 커서 파라미터(lastSeenId, firstSeenId) 병합 처리
  - extraParams 인자를 통해 조건 추가 가능하도록 구조 개선
  - 요청 전송 시 병합된 파라미터 콘솔 출력으로 디버깅 용이성 확보

- CursorPagination
  - lastSeenId / firstSeenId 존재 시에만 요청하도록 조건부 호출
  - 회원 모드일 경우 검색 비활성화 유지

- 검색 후 커서 이동 시에도 동일 조건으로 다음/이전 페이지 탐색 가능