### PR TITLE
[bugfix] 제출 검색 모달의 검색 기준을 loginId에서 nickname으로 변경

### DIFF
--- a/src/components/search/SubmissionSearchModal.jsx
+++ b/src/components/search/SubmissionSearchModal.jsx
@@ -9,7 +9,7 @@ const SubmissionSearchModal = ({ isOpen, onClose, onSearch }) => {
   };
 
   const [filters, setFilters] = useState({
-    loginId: "",
+    nickname: "",
     problemNumber: "",
     language: "",
     status: "",
@@ -42,7 +42,7 @@ const SubmissionSearchModal = ({ isOpen, onClose, onSearch }) => {
 
   const handleReset = () => {
     setFilters({
-      loginId: "",
+      nickname: "",
       problemNumber: "",
       language: "",
       status: "",
@@ -56,13 +56,13 @@ const SubmissionSearchModal = ({ isOpen, onClose, onSearch }) => {
         <h2 className="mb-4 text-xl font-semibold text-center">채점 내역 검색</h2>
 
         <form onSubmit={handleSubmit} className="flex flex-col gap-3">
-          {/* 아이디 */}
+          {/* 닉네임 */}
           <input
             type="text"
-            name="loginId"
-            value={filters.loginId}
+            name="nickname"
+            value={filters.nickname}
             onChange={handleChange}
-            placeholder="아이디"
+            placeholder="닉네임"
             className="px-3 py-2 border border-gray-300 rounded"
           />
 


### PR DESCRIPTION
- filters 상태 및 reset 로직에서 loginId 필드 제거, nickname 필드 추가
- 입력 필드 name/value를 nickname으로 변경
- placeholder 및 주석 문구를 '아이디' → '닉네임'으로 교체
- 검색 요청 시 nickname 기반 필터 전달로 일관성 확보

- 제출 내역 검색을 회원 닉네임 기준으로 수행하도록 수정