### PR TITLE
[bugfix] 제출 내역 페이지 검색 초기화 시 모달 입력값 및 커서 상태가 남는 문제 수정

### DIFF
--- a/src/components/pagination/CursorPagination.jsx
+++ b/src/components/pagination/CursorPagination.jsx
@@ -1,8 +1,16 @@
-import React, { useState } from "react";
-import SubmissionSearchModal from "../search/SubmissionSearchModal"; // ✅ 교체됨
+import React, { useEffect, useState } from "react";
+import SubmissionSearchModal from "../search/SubmissionSearchModal";
 
-const CursorPagination = ({ hasNext, hasPrev, onNext, onPrev, onSearch }) => {
+const CursorPagination = ({ hasNext, hasPrev, onNext, onPrev, onSearch, resetTrigger }) => {
   const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [resetSignal, setResetSignal] = useState(0);
+
+  // ✅ resetTrigger가 바뀔 때마다 모달 초기화 신호 전송
+  useEffect(() => {
+    if (resetTrigger > 0) {
+      setResetSignal((prev) => prev + 1);
+    }
+  }, [resetTrigger]);
 
   return (
     <>
@@ -44,6 +52,7 @@ const CursorPagination = ({ hasNext, hasPrev, onNext, onPrev, onSearch }) => {
           onSearch(filters);
           setIsSearchOpen(false);
         }}
+        resetSignal={resetSignal} // ✅ 전달
       />
     </>
   );

--- a/src/components/search/SubmissionSearchModal.jsx
+++ b/src/components/search/SubmissionSearchModal.jsx
@@ -1,6 +1,6 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 
-const SubmissionSearchModal = ({ isOpen, onClose, onSearch }) => {
+const SubmissionSearchModal = ({ isOpen, onClose, onSearch, resetSignal }) => {
   const LANGUAGE_VERSION_MAP = {
     Java: [1001, 1002, 1003, 1004],
     "C++": [1005, 1006, 1007, 1008, 1009, 1010],
@@ -15,6 +15,17 @@ const SubmissionSearchModal = ({ isOpen, onClose, onSearch }) => {
     status: "",
     submissionId: ""
   });
+
+  // ✅ resetSignal 변경 시 입력값 전체 초기화
+  useEffect(() => {
+    setFilters({
+      nickname: "",
+      problemNumber: "",
+      language: "",
+      status: "",
+      submissionId: ""
+    });
+  }, [resetSignal]);
 
   if (!isOpen) return null;
 

--- a/src/pages/SubmissionListPage.jsx
+++ b/src/pages/SubmissionListPage.jsx
@@ -12,6 +12,7 @@ const SubmissionListPage = () => {
   const [lastSeenId, setLastSeenId] = useState(null);
   const [totalCount, setTotalCount] = useState(null);
   const [searchParams, setSearchParams] = useState({});
+  const [resetTrigger, setResetTrigger] = useState(0); // ✅ 추가
   const size = 20;
 
   const { memberId } = useParams();
@@ -22,12 +23,8 @@ const SubmissionListPage = () => {
     try {
       const url = memberId ? `/submissions/page/member/${memberId}` : "/submissions/search";
 
-      // 이전 검색조건 유지
-      const mergedParams = {
-        size,
-        ...searchParams,
-        ...extraParams
-      };
+      // ✅ reset 모드일 경우 검색 조건 무시
+      const mergedParams = extraParams.reset ? { size } : { size, ...searchParams, ...extraParams };
 
       console.log("요청 파라미터:", mergedParams);
 
@@ -43,6 +40,9 @@ const SubmissionListPage = () => {
       if (content.length > 0) {
         setFirstSeenId(content[0].submissionId);
         setLastSeenId(content[content.length - 1].submissionId);
+      } else {
+        setFirstSeenId(null);
+        setLastSeenId(null);
       }
     } catch (error) {
       console.error("Failed to fetch submissions:", error);
@@ -67,13 +67,17 @@ const SubmissionListPage = () => {
     if (Object.keys(activeFilters).length === 0) return;
 
     setSearchParams(activeFilters);
+    setFirstSeenId(null);
+    setLastSeenId(null);
     fetchSubmissions(activeFilters);
   };
 
-  /** ✅ 전체 보기로 돌아가기 */
   const handleResetSearch = () => {
     setSearchParams({});
-    fetchSubmissions();
+    setFirstSeenId(null);
+    setLastSeenId(null);
+    fetchSubmissions({ reset: true }); // ✅ 검색 조건 완전 초기화
+    setResetTrigger((prev) => prev + 1); // ✅ 모달 입력값 초기화 트리거
   };
 
   const isSearching = Object.keys(searchParams).length > 0;
@@ -133,6 +137,7 @@ const SubmissionListPage = () => {
           }}
           onSearch={handleSearch}
           searchTypes={memberId ? null : []}
+          resetTrigger={resetTrigger} // ✅ 전달
         />
       </div>
     </div>


### PR DESCRIPTION
- SubmissionListPage
  - resetTrigger 상태 추가 및 전체 보기 클릭 시 증가시켜 모달 리셋 트리거
  - fetchSubmissions에서 reset 모드 시 기존 searchParams 무시
  - firstSeenId, lastSeenId 초기화 처리

- CursorPagination
  - resetTrigger 변경 감지 후 resetSignal 전달(useEffect)
  - SubmissionSearchModal로 resetSignal 전달

- SubmissionSearchModal
  - resetSignal 변경 시 useEffect로 입력 필드 전부 초기화
  - nickname, problemNumber, language, status, submissionId 초기 상태 복원

- 전체 보기로 돌아가기 시 검색 조건, 커서, 모달 입력값까지 완전 초기화되도록 수정