### PR TITLE
[bugfix] 문제 제출 후 이동 시 닉네임 정보 전달 누락 수정

### DIFF
--- a/src/pages/ProblemSolvePage.jsx
+++ b/src/pages/ProblemSolvePage.jsx
@@ -64,7 +64,10 @@ const ProblemSolvePage = () => {
 
       const { data } = await AxiosInstance.post("/submissions", payload);
       if (data.success) {
-        navigate(`/submissions/member/${memberId}`);
+        const member = JSON.parse(localStorage.getItem("member"));
+        navigate(`/submissions/member/${memberId}`, {
+          state: { nickname: member.nickname }
+        });
       } else {
         alert("제출에 실패했습니다.");
       }


### PR DESCRIPTION
- 제출 성공 시 localStorage에서 member 객체 파싱
- navigate 호출 시 state에 { nickname } 추가 전달
- 제출 후 회원 제출 내역 페이지에서 닉네임 표시 정상화